### PR TITLE
Add backend url setting from env variables during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Frontend works with NodeJS and uses React. It makes requests to backend API to g
 
 ### Local
 
-You need to define `REACT_APP_BACKEND_URL` variable during the build or start stage, due to add correct links to backend service on a service html page.
+By default `REACT_APP_BACKEND_URL` points to `http://localhost:8000`, it is OK for local development and runs. You should change it to whatever-else backend container URL during the runtime.
 
 ```
 cd frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       context: frontend/.
       args:
         REACT_APP_FRONT_VERSION: "1.0.0"
-        REACT_APP_BACKEND_URL: "http://127.0.0.1:8000"
     image: etoosamoe/eto-frontend:latest
     # enable `platform: linux/arm64/v8` if you use ARM
     #platform: linux/arm64/v8

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 node:20.12.1-bookworm as build
 ENV NODE_ENV=production
 # Define build-time variables
 ARG REACT_APP_FRONT_VERSION
-ARG REACT_APP_BACKEND_URL
+ENV REACT_APP_FRONT_VERSION=$REACT_APP_FRONT_VERSION
 
 WORKDIR /usr/src/app
 
@@ -17,9 +17,20 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1.25.2
+LABEL maintainer="Yuriy Semyenkov <yuriy.semyenkov@gmail.com>" \
+      version="1.0.0"
 
 COPY --from=build /usr/src/app/build/ /usr/share/nginx/html
 COPY --from=build /usr/src/app/nginx.conf /etc/nginx/conf.d/default.conf
 
-LABEL maintainer="Yuriy Semyenkov <yuriy.semyenkov@gmail.com>" \
-      version="1.0.0"
+# Copy entrypoint script to dynamically generate config.js
+COPY entrypoint.sh /entrypoint.sh
+
+# Make entrypoint script executable
+RUN chmod +x /entrypoint.sh
+
+# Use entrypoint script
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,3 @@
+window._env_ = {
+    REACT_APP_BACKEND_URL: "http://localhost:8000"
+  };

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Generate config.js file
+cat <<EOF > /usr/share/nginx/html/config.js
+window._env_ = {
+  REACT_APP_BACKEND_URL: "$REACT_APP_BACKEND_URL"
+};
+EOF
+
+exec "$@"

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>eto-app</title>
+    <script src="%PUBLIC_URL%/config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import Axios from 'axios';
 import Modal from 'react-modal';
 
 Modal.setAppElement('#root');
-const backendServerUrl = process.env.REACT_APP_BACKEND_URL;
+const backendServerUrl = window._env_.REACT_APP_BACKEND_URL || process.env.REACT_APP_BACKEND_URL;
 const frontendVersion = process.env.REACT_APP_FRONT_VERSION;
 if (!backendServerUrl) {
   console.error('REACT_APP_BACKEND_URL environment variable is not set.');


### PR DESCRIPTION
Now you can set `REACT_APP_BACKEND_URL` variable in `frontend/.env` file or set it during the container/pod runtime.