### PR TITLE
Add real-ip forwarding to Nginx

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,6 +6,9 @@ upstream backend {
 server {
   listen 80;
 
+  set_real_ip_from 192.168.0.0/16;
+  real_ip_header X-Forwarded-For;
+
   location / {
     root   /usr/share/nginx/html;
     index  index.html;


### PR DESCRIPTION
- Add some parameters to save the real client's IP from loadbalancer or whatever stands in front of frontend container. For now it allows getting IP from 192.168.0.0/16 which is my pod network, but I suppose somewhen I'm going to change it to 0.0.0.0/0.